### PR TITLE
Improve documentation and result object handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@ methods: {
 | disableInput          | Boolean              |          |           | to disable the input|
 | name                  | String               |          |           | name attribute for the `value` input|
 | resultsProperty       | String               |          |           | property api results are keyed under|
-| resultsValue          | String               |          |           | property to use for the `value`|
-| resultsDisplay        | String               |          |           | property to use for the `display`|
+| resultsValue          | String               |          | 'id'      | property to use for the `value`|
+| resultsDisplay        | String               |          | 'name'    | property to use for the `display`|
 | requestHeaders        | Object               |          |           | extra headers appended to the request|
 | showNoResults         | Boolean              |          | true      | To show a message that no results were found|
 | clearButtonIcon       | String               |          |           | Optionally provide an icon css class|

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -331,9 +331,19 @@ export default {
      * @return {String}
      */
     formatDisplay (obj) {
-      return typeof this.resultsDisplay === 'function'
-        ? this.resultsDisplay(obj)
-        : obj[this.resultsDisplay] ? obj[this.resultsDisplay] : obj.name
+      switch (typeof this.resultsDisplay) {
+        case 'function':
+          return this.resultsDisplay(obj)
+        case 'string':
+          if (obj[this.resultsDisplay]) {
+            return obj[this.resultsDisplay]
+          } else {
+            let msg = '"' + this.resultsDisplay + '"' + ' property expected on result but is not defined.'
+            throw new Error(msg)
+          }
+        default:
+          throw new TypeError()
+      }
     },
 
     up () {


### PR DESCRIPTION
Avoid an unhelpful`t.formatDisplay(...) is undefined` error message when the expected object property is missing.