### PR TITLE
Adjust up key handling.

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -337,6 +337,10 @@ export default {
     },
 
     up () {
+      if (this.selectedIndex === null) {
+        this.selectedIndex = this.results.length - 1
+        return
+      }
       this.selectedIndex = (this.selectedIndex === 0) ? this.results.length - 1 : this.selectedIndex - 1
     },
     down () {


### PR DESCRIPTION
If the up key is pressed on the input field the selectedIndex becomes
increasingly negative, hence the down key must then be pressed an equal
number of times (to "cancel" the up keypress).

This could be fixed by tested `selectedIndex < 0`, as well as the
existing test for `null`.  However, instead, change up to wrap to list
end, consistent with down wrapping to the top and helpful for long
lists.