### PR TITLE
Allow `source` to be a URL-returning function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ methods: {
 ```
 ## Available props
 
-| Prop                  | Type                 | Required | Default   | Description|
-|-----------------------|----------------------|----------|-----------|------------|
-| source                | String\|Object\|Array| true     |           | data source for the results|
-| placeholder           | String               |          | 'Search'  | input placeholder|
-| initialValue          | String\|Number       |          |           | starting value|
-| initialDisplay        | String               |          |           | starting display value|
-| inputClass            | String\|Object       |          |           | css class for the input div|
-| disableInput          | Boolean              |          |           | to disable the input|
-| name                  | String               |          |           | name attribute for the `value` input|
-| resultsProperty       | String               |          |           | property api results are keyed under|
-| resultsValue          | String               |          | 'id'      | property to use for the `value`|
-| resultsDisplay        | String               |          | 'name'    | property to use for the `display`|
-| requestHeaders        | Object               |          |           | extra headers appended to the request|
-| showNoResults         | Boolean              |          | true      | To show a message that no results were found|
-| clearButtonIcon       | String               |          |           | Optionally provide an icon css class|
+| Prop                  | Type                        | Required | Default   | Description |
+|-----------------------|-----------------------------|----------|-----------|-------------|
+| source                | String\|Func\|Object\|Array |          | true      | data source for the results|
+| placeholder           | String                      |          | 'Search'  | input placeholder|
+| initialValue          | String\|Number              |          |           | starting value|
+| initialDisplay        | String                      |          |           | starting display value|
+| inputClass            | String\|Object              |          |           | css class for the input div|
+| disableInput          | Boolean                     |          |           | to disable the input|
+| name                  | String                      |          |           | name attribute for the `value` input|
+| resultsProperty       | String                      |          |           | property api results are keyed under|
+| resultsValue          | String                      |          | 'id'      | property to use for the `value`|
+| resultsDisplay        | String                      |          | 'name'    | property to use for the `display`|
+| requestHeaders        | Object                      |          |           | extra headers appended to the request|
+| showNoResults         | Boolean                     |          | true      | To show a message that no results were found|
+| clearButtonIcon       | String                      |          |           | Optionally provide an icon css class|
 
 ## Available events
 

--- a/src/Demo.vue
+++ b/src/Demo.vue
@@ -9,7 +9,7 @@
       <p>If results are returned under a specific key you can set that via <em>apiResultsProperty</em> key</p>
 
       <div class="example">
-        <h5>Example</h5>
+        <h5>Example string source</h5>
         <autocomplete
           source="https://api.github.com/search/repositories?q="
           results-property="items"
@@ -18,11 +18,6 @@
           @clear="setXHRValue({})">
         </autocomplete>
 
-        <div class="results" v-if="apiResults">
-          <p>Results:</p>
-          <pre>{{ apiResults }}</pre>
-        </div>
-
         <code>
     &lt;autocomplete
       source="https://api.github.com/search/repositories?q="
@@ -30,6 +25,37 @@
       results-display="full_name"&gt;
     &lt;/autocomplete&gt;
         </code>
+
+        <br>
+
+        <h5>Example string-valued function</h5>
+        <autocomplete
+          :source="urlFunction"
+          results-property="items"
+          results-display="full_name"
+          @selected="setXHRValue"
+          @clear="setXHRValue({})">
+        </autocomplete>
+
+        <code>
+    &lt;autocomplete
+      :source="urlFunction"
+      results-property="items"
+      results-display="full_name"&gt;
+    &lt;/autocomplete&gt;
+
+    methods: {
+      urlFunction (input) {
+        return 'https://api.github.com/search/repositories?q=' + input
+      }
+    }
+        </code>
+
+        <div class="results" v-if="apiResults">
+          <p>Results:</p>
+          <pre>{{ apiResults }}</pre>
+        </div>
+
 
       </div>
     </div>
@@ -192,6 +218,9 @@ export default {
     }
   },
   methods: {
+    urlFunction (input) {
+      return 'https://api.github.com/search/repositories?q=' + input
+    },
     setObjValue (obj) {
       this.objectResults = obj
     },

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -64,9 +64,12 @@ export default {
   props: {
     /**
      * Data source for the results
+     *   `String` is a url, typed input will be appended
+     *   `Function` received typed input, and must return a string; to be used as a url
+     *   `Array` and `Object` (see `results-property`) are used directly
      */
     source: {
-      type: [String, Array, Object],
+      type: [String, Function, Array, Object],
       required: true
     },
     /**
@@ -205,7 +208,17 @@ export default {
             return
           }
           this.loading = true
-          this.resourceSearch()
+
+          this.resourceSearch(this.source + this.display)
+          break
+        case 'function':
+          // No resource search with no input
+          if (!this.display || this.display.length < 1) {
+            return
+          }
+          this.loading = true
+
+          this.resourceSearch(this.source(this.display))
           break
         case 'object':
           this.loading = true
@@ -216,7 +229,7 @@ export default {
       }
     },
 
-    resourceSearch: debounce(function () {
+    resourceSearch: debounce(function (url) {
       if (!this.display) {
         this.results = []
         this.loading = false
@@ -224,7 +237,7 @@ export default {
       }
 
       // query param should be a setting, rather than appended.
-      let promise = fetch(this.source + this.display, {
+      let promise = fetch(url, {
         method: 'get',
         credentials: 'same-origin',
         headers: this.getHeaders()


### PR DESCRIPTION
Currently, when `source` is string-valued it naively appends the typed
input ("display" data). This limits its usefulness against more
complicated endpoints.

Permit `source` to be a function which receives the typed input and
returns a string. The string will be used as the endpoint URL.

(A future improvement would allow the function to return a `Request`
object, to better expose the complete Fetch API.)