### PR TITLE
Improve API endpoint compatibility by preventing CORS preflight request.

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -225,6 +225,7 @@ export default {
 
       // query param should be a setting, rather than appended.
       let promise = fetch(this.source + this.display, {
+        referrerPolicy: 'no-referrer',
         method: 'get',
         credentials: 'same-origin',
         headers: this.getHeaders()
@@ -257,8 +258,7 @@ export default {
 
     getHeaders () {
       const headers = {
-        'Accept': 'application/json, text/plain, */*',
-        'Content-Type': 'application/json'
+        'Accept': 'application/json, text/plain, */*'
       }
 
       if (this.requestHeaders) {


### PR DESCRIPTION
The `Content-Type` and `Referrer` headers cause browsers implementing
CORS to send a preflight (`OPTION`) request. If we remove them, our
`GET` requests will be "simple", and no longer trigger a preflight.

Preventing the preflight and using a "simple" request makes it easier to
work with endpoints that do not implement an `OPTIONS` response, but
nevertheless do set `Access-Control-Allow-Origin` on the `GET` response.
(Especially development environments.)

We do not need `Content-Type` because our `GET` requests have no
payload.

Users requiring `Referrer` may add it explicitly with `<autocomplete
:request-headers="...">`.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy

Tested on latest Chrome, Firefox and Safari. Should be fine back to
June/July 2016 (Chrome 52, Firefox 47).  Note, the MDN browser compat
info for Request.referrerPolicy Safari seems incomplete: refererPolicy
does work.