### PR TITLE
Keep selected item visible in results list.

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -195,6 +195,13 @@ export default {
           color: '#ccc'
         }
       }
+    },
+    selectedElement () {
+      let resultsListElement = this.$refs.resultsList
+      let selectedIndexAsChild = this.selectedIndex + 1 // DOM children are 1-based.
+      let selectedElementSelector = `:nth-child(${selectedIndexAsChild})`
+      let selectedElement = resultsListElement.querySelector(selectedElementSelector)
+      return selectedElement
     }
   },
   methods: {
@@ -392,17 +399,11 @@ export default {
 
       if (noneOrFirstSelected) {
         this.selectedIndex = this.results.length - 1
-
         resultsListElement.scrollTop = resultsListElement.scrollHeight - resultsListElement.clientHeight
       } else {
         this.selectedIndex -= 1
-
-        let selectedIndexAsChild = this.selectedIndex + 1 // DOM children are 1-based.
-        let selectedElementSelector = `:nth-child(${selectedIndexAsChild})`
-        let selectedElement = resultsListElement.querySelector(selectedElementSelector)
-
-        if (!this.isVisibleInside(resultsListElement, selectedElement)) {
-          resultsListElement.scrollTop -= selectedElement.clientHeight
+        if (this.selectedIsOutsideResultList()) {
+          resultsListElement.scrollTop -= this.selectedElement.clientHeight
         }
       }
     },
@@ -417,31 +418,21 @@ export default {
 
       if (noneOrLastSelected) {
         this.selectedIndex = 0
-
         resultsListElement.scrollTop = 0
       } else {
         this.selectedIndex += 1
-
-        let selectedIndexAsChild = this.selectedIndex + 1 // DOM children are 1-based.
-        let selectedElementSelector = `:nth-child(${selectedIndexAsChild})`
-        let selectedElement = resultsListElement.querySelector(selectedElementSelector)
-
-        if (!this.isVisibleInside(resultsListElement, selectedElement)) {
-          resultsListElement.scrollTop += selectedElement.clientHeight
+        if (this.selectedIsOutsideResultList()) {
+          resultsListElement.scrollTop += this.selectedElement.clientHeight
         }
       }
     },
-    /**
-     * Determine if an element is (or will be) visible within parent client
-     * dimensions for scrolling purposes.
-     * @param {DOM Element} parentElement
-     * @param {DOM Element} childElement
-     * @return {Boolean}
-     */
-    isVisibleInside (parentElement, childElement) {
-      let parentRect = parentElement.getBoundingClientRect()
-      let childRect = childElement.getBoundingClientRect()
-      return (childRect.top >= parentRect.top && childRect.bottom <= parentRect.bottom)
+    selectedIsOutsideResultList () {
+      let resultsListElement = this.$refs.resultsList
+      let resultsListElementRect = resultsListElement.getBoundingClientRect()
+      let selectedElementRect = this.selectedElement.getBoundingClientRect()
+
+      return (selectedElementRect.top <= resultsListElementRect.top ||
+              selectedElementRect.bottom >= resultsListElementRect.bottom)
     },
 
     /**

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -30,8 +30,7 @@
       </span>
     </div>
 
-    <ul v-show="showResults" class="autocomplete__results" :style="listStyle" ref="resultsList">
-
+    <ul v-show="showResults" class="autocomplete__results" :style="listStyle">
       <slot name="results">
         <!-- error -->
         <li v-if="hasError" class="autocomplete__results__item autocomplete__results__item--error">{{ error }}</li>
@@ -195,9 +194,6 @@ export default {
           color: '#ccc'
         }
       }
-    },
-    selectedElement () {
-      return this.$refs.resultsList.children[this.selectedIndex]
     }
   },
   methods: {
@@ -389,46 +385,69 @@ export default {
      * Focus on the previous results item
      */
     up () {
-      let resultsListElement = this.$refs.resultsList
-
       let noneOrFirstSelected = this.selectedIndex === null || this.selectedIndex === 0
 
       if (noneOrFirstSelected) {
         this.selectedIndex = this.results.length - 1
-        resultsListElement.scrollTop = resultsListElement.scrollHeight - resultsListElement.clientHeight
       } else {
         this.selectedIndex -= 1
-        if (this.selectedIsOutsideResultList()) {
-          resultsListElement.scrollTop -= this.selectedElement.clientHeight
-        }
       }
+
+      this.syncScrollWithSelectedPosition()
     },
 
     /**
      * Focus on the next results item
      */
     down () {
-      let resultsListElement = this.$refs.resultsList
-
       let noneOrLastSelected = this.selectedIndex === null || this.selectedIndex === this.results.length - 1
 
       if (noneOrLastSelected) {
         this.selectedIndex = 0
-        resultsListElement.scrollTop = 0
       } else {
         this.selectedIndex += 1
-        if (this.selectedIsOutsideResultList()) {
-          resultsListElement.scrollTop += this.selectedElement.clientHeight
+      }
+
+      this.syncScrollWithSelectedPosition()
+    },
+
+    syncScrollWithSelectedPosition () {
+      /*
+       * NOTE:
+       *
+       * Using .offset(Top|Height) values will not take into consideration
+       * applied transformations.  Using .getBoundingClientRect() will
+       * provide post-transformation sizes, however the values are not
+       * relative to the parent element, and are also affected by page
+       * scroll.
+       */
+
+      let resultsListElement = this.$el.querySelector('.autocomplete__results')
+      let selectedElement = resultsListElement.children[this.selectedIndex]
+
+      let selectedElementTop = selectedElement.offsetTop
+      let selectedElementHeight = selectedElement.offsetHeight
+      let selectedElementBottom = selectedElementTop + selectedElementHeight
+
+      let visibleScrollAreaTop = resultsListElement.scrollTop
+      let visibleScrollAreaHeight = resultsListElement.clientHeight
+      let visibleScrollAreaBottom = visibleScrollAreaTop + visibleScrollAreaHeight
+
+      /*
+       * Only adjust the scroll position if the scroll area can display more
+       * than one selection choice; handles an unlikely UI/UX situation, where
+       * each choice is actually taller than the visible scroll area (the user
+       * would never see a complete choice in the scroll area), a strange UI.
+       */
+      let scrollAreaFitsManyChoices = selectedElementHeight < visibleScrollAreaHeight
+
+      if (scrollAreaFitsManyChoices) {
+        if (selectedElementTop < visibleScrollAreaTop) {
+          resultsListElement.scrollTop = selectedElementTop
+        } else if (selectedElementBottom > visibleScrollAreaBottom) {
+          resultsListElement.scrollTop = selectedElementBottom - visibleScrollAreaHeight
         }
       }
-    },
-    selectedIsOutsideResultList () {
-      let resultsListElement = this.$refs.resultsList
-      let resultsListElementRect = resultsListElement.getBoundingClientRect()
-      let selectedElementRect = this.selectedElement.getBoundingClientRect()
-
-      return (selectedElementRect.top <= resultsListElementRect.top ||
-              selectedElementRect.bottom >= resultsListElementRect.bottom)
     },
 
     /**

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -30,7 +30,8 @@
       </span>
     </div>
 
-    <ul v-show="showResults" class="autocomplete__results" :style="listStyle">
+    <ul v-show="showResults" class="autocomplete__results" :style="listStyle" ref="resultsList">
+
       <slot name="results">
         <!-- error -->
         <li v-if="hasError" class="autocomplete__results__item autocomplete__results__item--error">{{ error }}</li>
@@ -385,22 +386,54 @@ export default {
      * Focus on the previous results item
      */
     up () {
-      if (this.selectedIndex === null) {
+      let resultsList = this.$refs.resultsList
+
+      if (this.selectedIndex === null || this.selectedIndex === 0) {
         this.selectedIndex = this.results.length - 1
-        return
+        resultsList.scrollTop = resultsList.scrollHeight - resultsList.clientHeight
+      } else {
+        let [ selectedElement ] = resultsList.getElementsByClassName('autocomplete__selected')
+        this.selectedIndex -= 1
+        if (!this.isVisibleInside(resultsList, selectedElement, -1)) {
+          resultsList.scrollTop -= selectedElement.clientHeight
+        }
       }
-      this.selectedIndex = (this.selectedIndex === 0) ? this.results.length - 1 : this.selectedIndex - 1
     },
 
     /**
      * Focus on the next results item
      */
     down () {
-      if (this.selectedIndex === null) {
+      let resultsList = this.$refs.resultsList
+
+      if (this.selectedIndex === null || this.selectedIndex === this.results.length - 1) {
         this.selectedIndex = 0
-        return
+        resultsList.scrollTop = 0
+      } else {
+        let [ selectedElement ] = resultsList.getElementsByClassName('autocomplete__selected')
+        this.selectedIndex += 1
+        if (!this.isVisibleInside(resultsList, selectedElement, 1)) {
+          resultsList.scrollTop += selectedElement.clientHeight
+        }
       }
-      this.selectedIndex = (this.selectedIndex === this.results.length - 1) ? 0 : this.selectedIndex + 1
+    },
+    /**
+     * Determine if an element is (or will be) visible within parent client
+     * dimensions for scrolling purposes.
+     * @param {Object} parentElement
+     * @param {Object} childElement
+     * @param {Integer} offset
+     * @return {Boolean}
+     */
+    isVisibleInside (parentElement, childElement, offset) {
+      let parent = parentElement.getBoundingClientRect()
+      let child = childElement.getBoundingClientRect()
+      let childTop = child.top + (childElement.clientHeight * offset)
+      let childBottom = child.bottom + (childElement.clientHeight * offset)
+      return (
+        childTop >= parent.top &&
+        childBottom <= parent.bottom
+      )
     },
 
     /**

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -386,16 +386,23 @@ export default {
      * Focus on the previous results item
      */
     up () {
-      let resultsList = this.$refs.resultsList
+      let resultsListElement = this.$refs.resultsList
 
-      if (this.selectedIndex === null || this.selectedIndex === 0) {
+      let noneOrFirstSelected = this.selectedIndex === null || this.selectedIndex === 0
+
+      if (noneOrFirstSelected) {
         this.selectedIndex = this.results.length - 1
-        resultsList.scrollTop = resultsList.scrollHeight - resultsList.clientHeight
+
+        resultsListElement.scrollTop = resultsListElement.scrollHeight - resultsListElement.clientHeight
       } else {
-        let [ selectedElement ] = resultsList.getElementsByClassName('autocomplete__selected')
         this.selectedIndex -= 1
-        if (!this.isVisibleInside(resultsList, selectedElement, -1)) {
-          resultsList.scrollTop -= selectedElement.clientHeight
+
+        let selectedIndexAsChild = this.selectedIndex + 1 // DOM children are 1-based.
+        let selectedElementSelector = `:nth-child(${selectedIndexAsChild})`
+        let selectedElement = resultsListElement.querySelector(selectedElementSelector)
+
+        if (!this.isVisibleInside(resultsListElement, selectedElement)) {
+          resultsListElement.scrollTop -= selectedElement.clientHeight
         }
       }
     },
@@ -404,36 +411,37 @@ export default {
      * Focus on the next results item
      */
     down () {
-      let resultsList = this.$refs.resultsList
+      let resultsListElement = this.$refs.resultsList
 
-      if (this.selectedIndex === null || this.selectedIndex === this.results.length - 1) {
+      let noneOrLastSelected = this.selectedIndex === null || this.selectedIndex === this.results.length - 1
+
+      if (noneOrLastSelected) {
         this.selectedIndex = 0
-        resultsList.scrollTop = 0
+
+        resultsListElement.scrollTop = 0
       } else {
-        let [ selectedElement ] = resultsList.getElementsByClassName('autocomplete__selected')
         this.selectedIndex += 1
-        if (!this.isVisibleInside(resultsList, selectedElement, 1)) {
-          resultsList.scrollTop += selectedElement.clientHeight
+
+        let selectedIndexAsChild = this.selectedIndex + 1 // DOM children are 1-based.
+        let selectedElementSelector = `:nth-child(${selectedIndexAsChild})`
+        let selectedElement = resultsListElement.querySelector(selectedElementSelector)
+
+        if (!this.isVisibleInside(resultsListElement, selectedElement)) {
+          resultsListElement.scrollTop += selectedElement.clientHeight
         }
       }
     },
     /**
      * Determine if an element is (or will be) visible within parent client
      * dimensions for scrolling purposes.
-     * @param {Object} parentElement
-     * @param {Object} childElement
-     * @param {Integer} offset
+     * @param {DOM Element} parentElement
+     * @param {DOM Element} childElement
      * @return {Boolean}
      */
-    isVisibleInside (parentElement, childElement, offset) {
-      let parent = parentElement.getBoundingClientRect()
-      let child = childElement.getBoundingClientRect()
-      let childTop = child.top + (childElement.clientHeight * offset)
-      let childBottom = child.bottom + (childElement.clientHeight * offset)
-      return (
-        childTop >= parent.top &&
-        childBottom <= parent.bottom
-      )
+    isVisibleInside (parentElement, childElement) {
+      let parentRect = parentElement.getBoundingClientRect()
+      let childRect = childElement.getBoundingClientRect()
+      return (childRect.top >= parentRect.top && childRect.bottom <= parentRect.bottom)
     },
 
     /**

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -197,11 +197,7 @@ export default {
       }
     },
     selectedElement () {
-      let resultsListElement = this.$refs.resultsList
-      let selectedIndexAsChild = this.selectedIndex + 1 // DOM children are 1-based.
-      let selectedElementSelector = `:nth-child(${selectedIndexAsChild})`
-      let selectedElement = resultsListElement.querySelector(selectedElementSelector)
-      return selectedElement
+      return this.$refs.resultsList.children[this.selectedIndex]
     }
   },
   methods: {


### PR DESCRIPTION
@charliekassel I talked with @alanbhamilton about !20 (which closes #19).  I've taken the PR, and re-worked it, hoping to make it more likely for merge.  I left the commits unsquashed, if you want to review the evolution.  Prior to merge, I'd rebase and squash them.

There are a few considerations:

* Avoids usage of `ref`, only because the component doesn't use them anywhere else.  Instead, `$el.querySelector()` is used once.

* `selectedElement` could be a computed property, but it's might not be worth burdening Vue with re-computation.  It is used on every `up()` and `down()` call, but *only* in those functions, and Vue may re-compute it in other circumstances, even when not necessary (any access to `selectedIndex` might cause re-computation, as it's the dependency).

* Calculations use the `.offset*` properties.  These do not consider applied transformations (e.g., scaling).  However, I suspect these will be a rare and suggest waiting for a "bug" report before re-working it with `.getClientBoundingRect()` (which provides sizes *after* transformations have been applied; that is, rendered sizes).  What are your thoughts?  After discussion, I'll remove the code comment prior to merge.

* There is an uncommon possibility handled by the code: if the `<ul>` list of options is shorter than a single choice (that is, the visible scroll area doesn't fit a single choice element). In such a situation, the user will see only a partial choice.  This would be a very strange UI, but it could happen (presumably by accident) on mobile.  I've avoid trying to sync in this case, becuse there is nothing to do -- just allow the selection to move.  Although, it won't wrap, so it is somewhat broken.  I wonder if it's worth handling this at all.  I'd prefer to remove the special handing, and wait for a bug report.