### PR TITLE
Emit selected object on Enter

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -412,7 +412,10 @@ export default {
         return
       }
       this.select(this.results[this.selectedIndex])
-      this.$emit('enter', this.display)
+      this.$emit('enter', {
+        display: this.display,
+        selectedObject: this.results[this.selectedIndex]
+      })
     },
 
     /**


### PR DESCRIPTION
Changed the emit of the `enter` event, to also return the selected object (like the select() method).