### PR TITLE
fix example code in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ methods: {
   addDistributionGroup (group) {
     this.group = group
     // access the autocomplete component methods from the parent
-    this.$refs.autocomplete.clearValues()
+    this.$refs.autocomplete.clear()
   },
   authHeaders () {
     return {


### PR DESCRIPTION
As of commit 6403d41c116d0298c00b9eb2a7532e900ffcaf0e the clearValues() method has been removed and merged into the clear() method.

This just updates the README to show the correct way to clear the input field and avoid confusion.