### PR TITLE
Add support for callback to arbitrarily format the server response

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ methods: {
 | inputClass            | String\|Object              |          |           | css class for the input div|
 | disableInput          | Boolean                     |          |           | to disable the input|
 | name                  | String                      |          |           | name attribute for the `value` input|
+| setResults            | Function                    |          |           | Callback to format the server data |
 | resultsProperty       | String                      |          |           | property api results are keyed under|
 | resultsValue          | String                      |          | 'id'      | property to use for the `value`|
 | resultsDisplay        | String\|Function            |          | 'name'    | property to use for the `display` or custom function|

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ methods: {
 | inputClass            | String\|Object              |          |           | css class for the input div|
 | disableInput          | Boolean                     |          |           | to disable the input|
 | name                  | String                      |          |           | name attribute for the `value` input|
-| setResults            | Function                    |          |           | Callback to format the server data |
+| customSetResults      | Function                    |          |           | Callback to format the server data |
 | resultsProperty       | String                      |          |           | property api results are keyed under|
 | resultsValue          | String                      |          | 'id'      | property to use for the `value`|
 | resultsDisplay        | String\|Function            |          | 'name'    | property to use for the `display` or custom function|

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -140,6 +140,13 @@ export default {
     },
 
     /**
+     * Callback to format the server data
+     */
+    setResults: {
+      type: Function
+    },
+
+    /**
      * Whether to show the no results message
      */
     showNoResults: {
@@ -281,7 +288,11 @@ export default {
           throw new Error('Network response was not ok.')
         })
         .then(response => {
-          this.results = this.setResults(response)
+          if(this.setResults){
+            this.results = this.setResults(response)
+          } else {
+            this.results = this.defaultSetResults(response)
+          }
           if (this.results.length === 0) {
             this.$emit('noResults', {query: this.display})
           } else {
@@ -326,7 +337,7 @@ export default {
      * @param {Object|Array} response
      * @return {Array}
      */
-    setResults (response) {
+    defaultSetResults (response) {
       if (this.resultsProperty && response[this.resultsProperty]) {
         return response[this.resultsProperty]
       }

--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -142,7 +142,7 @@ export default {
     /**
      * Callback to format the server data
      */
-    setResults: {
+    customSetResults: {
       type: Function
     },
 
@@ -288,11 +288,7 @@ export default {
           throw new Error('Network response was not ok.')
         })
         .then(response => {
-          if(this.setResults){
-            this.results = this.setResults(response)
-          } else {
-            this.results = this.defaultSetResults(response)
-          }
+          this.results = this.setResults(response)
           if (this.results.length === 0) {
             this.$emit('noResults', {query: this.display})
           } else {
@@ -337,7 +333,10 @@ export default {
      * @param {Object|Array} response
      * @return {Array}
      */
-    defaultSetResults (response) {
+    setResults (response) {
+      if(this.customSetResults){
+        return this.customSetResults(response)
+      }
       if (this.resultsProperty && response[this.resultsProperty]) {
         return response[this.resultsProperty]
       }

--- a/test/unit/jest.conf.js
+++ b/test/unit/jest.conf.js
@@ -22,5 +22,6 @@ module.exports = {
     '!src/main.js',
     '!src/Demo.vue',
     '!**/node_modules/**'
-  ]
+  ],
+  testURL : 'http://localhost/'
 }


### PR DESCRIPTION
We have a use case where an existing server is returning a single object with a key value pair for each autocomplete item. Since we don't have control over the response format of the endpoint, we need something that will allow us reformat the response.

This adds an optional callback that allows for arbitrary reformatting of the data returned from the endpoint.