### PR TITLE
Abort last request before starting another

### DIFF
--- a/src/components/Autocomplete.vue
+++ b/src/components/Autocomplete.vue
@@ -193,7 +193,8 @@ export default {
       error: null,
       selectedId: null,
       selectedDisplay: null,
-      eventListener: false
+      eventListener: false,
+      lastRequestAbortController: null,
     }
   },
   computed: {
@@ -273,10 +274,16 @@ export default {
      * @param {String} url
      */
     request (url) {
+      if (this.lastRequestAbortController) {
+        this.lastRequestAbortController.abort();
+      }
+      this.lastRequestAbortController = new AbortController();
+            
       let promise = fetch(url, {
         method: this.method,
         credentials: this.getCredentials(),
-        headers: this.getHeaders()
+        headers: this.getHeaders(),
+        signal: this.lastRequestAbortController.signal
       })
 
       return promise
@@ -293,8 +300,10 @@ export default {
           this.loading = false
         })
         .catch(error => {
-          this.error = error.message
-          this.loading = false
+          if (error.name !== "AbortError") {
+            this.error = error.message
+            this.loading = false
+          }
         })
     },
 


### PR DESCRIPTION
I had an issue where sometimes requests made earlier during typing would resolve after the most recent one, which would wipe out the current results with invalid ones.

this update cancels the previous request before starting a new one.